### PR TITLE
Improved display of sale price filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ typings/
 npm-debug.log
 frontend/config.json
 extension/config.json
+**/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.7] - 2024-10-18
+### Changed
+- improved display of sale_price filter
+  - $ sign is displayed in front of price
+  - prices are rounded up ($49.99 to $50)
+  - range boundaries with * are displayed as text ($400 And Up)
+
 ## [1.0.6] - 2024-07-29
 ### Changed
 - fix sale_price filter

--- a/extension/.eslintrc
+++ b/extension/.eslintrc
@@ -6,5 +6,12 @@
   },
   "env":{
     "node": true
+  },
+  "rules": {
+    "no-console": "error",
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ]
   }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -7,14 +7,13 @@
     "lint": "eslint --ignore-path ../.gitignore --ext .js ."
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-standard": "^14.1.1",
+    "eslint": "^8.44.0",
+    "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1",
-    "lint-staged": "^10.1.2",
-    "standard": "^14.3.3"
+    "eslint-plugin-mocha": "^10.1.0",
+    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-promise": "^6.1.1",
+    "lint-staged": "^10.1.2"
   },
   "dependencies": {
     "request": "^2.88.2",


### PR DESCRIPTION
This pull request improves display of sales price filters:

- $ sign is displayed in front of price
- prices are rounded up ($49.99 to $50)
- range boundaries with * are displayed as text ($400 And Up)

![Bildschirmfoto 2024-10-18 um 13 17 01](https://github.com/user-attachments/assets/3d608c14-eb34-45b4-bfc9-c9bc0610776a) 
